### PR TITLE
snap: assume snapd 2.64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,8 @@ build-base: core22
 base: bare
 confinement: strict
 license: LGPL-2.1-or-later
+assumes:
+ - snapd2.64
 
 apps:
   strace-static:


### PR DESCRIPTION
Snapd 2.64 will be the first version of snapd compatible with the new strace -u UID:GID syntax. Using the assumes feature will prevent people from updating strace-static on an incompatible release of snapd.